### PR TITLE
[OPS-13422]: Fix missing files error

### DIFF
--- a/tasks/section_5/cis_5.1.3.yml
+++ b/tasks/section_5/cis_5.1.3.yml
@@ -9,17 +9,30 @@
             recurse: true
         register: logfiles
 
-      - name: "5.1.3 | PATCH | Ensure all logfiles have appropriate permissions and ownership | change permissions"
-        ansible.builtin.file:
+      - name: "5.1.3 | PATCH | Ensure all logfiles have appropriate permissions and ownership | check if files still exist"
+        ansible.builtin.stat:
             path: "{{ item.path }}"
-            mode: 'u-x,g-wx,o-rwx'
         loop: "{{ logfiles.files }}"
         loop_control:
             label: "{{ item.path }}"
+        register: logfile_stats
         when:
             - item.path != "/var/log/btmp"
             - item.path != "/var/log/utmp"
             - item.path != "/var/log/wtmp"
+
+      - name: "5.1.3 | PATCH | Ensure all logfiles have appropriate permissions and ownership | change permissions"
+        ansible.builtin.file:
+            path: "{{ item.item.path }}"
+            mode: 'u-x,g-wx,o-rwx'
+        loop: "{{ logfile_stats.results }}"
+        loop_control:
+            label: "{{ item.item.path }}"
+        when:
+            - not item.skipped | default(false)
+            - item.stat.exists
+
+
   when:
       - amzn2023cis_rule_5_1_3
   tags:
@@ -27,5 +40,6 @@
       - patch
       - logfiles
       - rule_5.1.3
-      - NIST800-53R5_AC-3
-      - NIST800-53R5_MP-5
+      - nist_sp800-53r5_AC-3
+      - nist_sp800-53r5_MP-5
+

--- a/tasks/section_5/cis_5.1.3.yml
+++ b/tasks/section_5/cis_5.1.3.yml
@@ -40,6 +40,5 @@
       - patch
       - logfiles
       - rule_5.1.3
-      - nist_sp800-53r5_AC-3
-      - nist_sp800-53r5_MP-5
-
+      - NIST800-53R5_AC-3
+      - NIST800-53R5_MP-5


### PR DESCRIPTION
We're forking the repo to add a check that verifies that the files the task wants to check the permission of exist before we try to set those permissions. 

